### PR TITLE
Fix Google login flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # S2DO
 S2DO, my personal YouTube Studio+
 (Very much a work in progress, not really meant for other people. Making this for my own channel)
+
+## Google Sign-In
+
+Replace the `CLIENT_ID` and `API_KEY` placeholders in `script.js` with your Google OAuth credentials to enable sign in and fetch your channel statistics.

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <title>YouTube Studio+</title>
   <link rel="stylesheet" href="style.css" />
 </head>
-<body>
+<body onload="handleClientLoad()">
   <div id="app">
     <header>
       <h1>YouTube Studio+</h1>
@@ -32,6 +32,7 @@
       <p>Logged in as: <span id="userEmail">guest</span></p>
     </footer>
   </div>
+  <script src="https://apis.google.com/js/api.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -5,12 +5,52 @@ document.getElementById('themeToggle').onclick = () => {
 
 let chartInstance;
 
-document.getElementById('loginBtn').onclick = () => {
-  document.getElementById('userEmail').innerText = "you@example.com";
-  document.getElementById('subscriberCount').innerText = "1,204";
-  document.getElementById('viewCount').innerText = "589,321";
-  drawChart();
-};
+const CLIENT_ID = 'YOUR_CLIENT_ID'; // TODO: replace with your OAuth client id
+const API_KEY = 'YOUR_API_KEY'; // TODO: replace with your API key
+
+const DISCOVERY_DOCS = ['https://www.googleapis.com/discovery/v1/apis/youtube/v3/rest'];
+const SCOPES = 'https://www.googleapis.com/auth/youtube.readonly';
+
+function handleClientLoad() {
+  gapi.load('client:auth2', initClient);
+}
+
+function initClient() {
+  gapi.client
+    .init({
+      apiKey: API_KEY,
+      clientId: CLIENT_ID,
+      discoveryDocs: DISCOVERY_DOCS,
+      scope: SCOPES,
+    })
+    .then(() => {
+      const authInstance = gapi.auth2.getAuthInstance();
+      updateSigninStatus(authInstance.isSignedIn.get());
+      document.getElementById('loginBtn').onclick = () =>
+        authInstance.signIn().then(loadChannelStats);
+    });
+}
+
+function updateSigninStatus(isSignedIn) {
+  if (isSignedIn) {
+    loadChannelStats();
+  }
+}
+
+function loadChannelStats() {
+  gapi.client.youtube.channels
+    .list({
+      part: 'snippet,statistics',
+      mine: true,
+    })
+    .then((response) => {
+      const channel = response.result.items[0];
+      document.getElementById('userEmail').innerText = channel.snippet.title;
+      document.getElementById('subscriberCount').innerText = channel.statistics.subscriberCount;
+      document.getElementById('viewCount').innerText = channel.statistics.viewCount;
+      drawChart();
+    });
+}
 
 function drawChart() {
   const ctx = document.getElementById('videoChart').getContext('2d');


### PR DESCRIPTION
## Summary
- implement Google OAuth sign-in and fetch channel stats
- load Google API client from index
- document how to provide OAuth credentials

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6859648ed1f083338198f29d67050a6d